### PR TITLE
Nova sintaxe para instanciar o Axios

### DIFF
--- a/binance-spot/index.js
+++ b/binance-spot/index.js
@@ -1,5 +1,5 @@
 require("dotenv").config();
-const axios = require("axios");
+const axios = require("axios").default;
 const crypto = require("crypto");
 const WebSocket = require("ws");
 


### PR DESCRIPTION
Olá prof.. Parece que com a versão mais recente do Axios, é necessário usar

const axios = require("axios").default;

Do contrário, ele dá um erro "axios is not a function".

Com esse ajuste, consegui fazer rodar o codigo.

Abs!